### PR TITLE
 Add README note about local secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,4 +79,5 @@ Workflow file:
 
 - `.github/workflows/ci.yml`
 
+Note: keep secrets such as `MONGODB_URI` and `GEMINI_API_KEY` only in local `.env` files and never commit them.
 


### PR DESCRIPTION
This pull request adds a small README clarification on secret handling for the project.

The immediate issue is operational rather than product-facing: the repository now relies on local environment variables for MongoDB and Gemini credentials, and it is easy for contributors to accidentally assume those values belong in tracked files. That creates a risk of leaking working credentials into the public repository.

The root cause is that the README previously documented Docker and CI usage but did not explicitly restate the secret-handling rule near the setup instructions. A contributor following the setup flow could infer the needed variables without seeing a direct warning in the main project documentation.

This change adds a concise note in the README telling contributors to keep `MONGODB_URI` and `GEMINI_API_KEY` only in local `.env` files and never commit them. The goal is to reduce accidental credential exposure while keeping the change minimal.

This was validated by checking the README diff and pushing the branch successfully. No application code or runtime behavior changed.
