### PR TITLE
Allow Docker Hub publish before Render is configured

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,27 +63,33 @@ jobs:
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
           RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
         run: |
-          if [ -n "${DOCKERHUB_USERNAME}" ] && [ -n "${DOCKERHUB_TOKEN}" ] && [ -n "${RENDER_DEPLOY_HOOK_URL}" ]; then
-            echo "can_release=true" >> "${GITHUB_OUTPUT}"
-            exit 0
+          if [ -n "${DOCKERHUB_USERNAME}" ] && [ -n "${DOCKERHUB_TOKEN}" ]; then
+            echo "can_publish=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "can_publish=false" >> "${GITHUB_OUTPUT}"
+            echo "::notice::Skipping Docker Hub publish because Docker Hub secrets are missing."
           fi
 
-          echo "can_release=false" >> "${GITHUB_OUTPUT}"
-          echo "::notice::Skipping Docker Hub publish and Render deploy because one or more release secrets are missing."
+          if [ -n "${RENDER_DEPLOY_HOOK_URL}" ]; then
+            echo "can_deploy=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "can_deploy=false" >> "${GITHUB_OUTPUT}"
+            echo "::notice::Skipping Render deploy because RENDER_DEPLOY_HOOK_URL is missing."
+          fi
 
       - name: Set up Docker Buildx
-        if: steps.release-check.outputs.can_release == 'true'
+        if: steps.release-check.outputs.can_publish == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        if: steps.release-check.outputs.can_release == 'true'
+        if: steps.release-check.outputs.can_publish == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push release image
-        if: steps.release-check.outputs.can_release == 'true'
+        if: steps.release-check.outputs.can_publish == 'true'
         env:
           IMAGE_REPOSITORY: docker.io/${{ secrets.DOCKERHUB_USERNAME }}/ai-homework-explainer
           IMAGE_TAG: ${{ github.sha }}
@@ -96,7 +102,7 @@ jobs:
             .
 
       - name: Trigger Render deployment
-        if: steps.release-check.outputs.can_release == 'true'
+        if: steps.release-check.outputs.can_publish == 'true' && steps.release-check.outputs.can_deploy == 'true'
         env:
           RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
         run: curl --fail --show-error --silent --request POST "${RENDER_DEPLOY_HOOK_URL}"


### PR DESCRIPTION
## Summary
- let the release job publish the Docker image when Docker Hub secrets are present
- keep the Render deploy step optional until `RENDER_DEPLOY_HOOK_URL` is added
- preserve the existing main-only release flow

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "YAML OK"'
- python3 -m pytest -q

## Why
Docker Hub stayed empty because the workflow required the Render hook secret before it would publish the image. This change lets the image publish first, so Render can later pull `latest`.
